### PR TITLE
Use secure file permissions for merge files

### DIFF
--- a/pacfiles-win.el
+++ b/pacfiles-win.el
@@ -59,7 +59,8 @@ EDIFF windows.")
         (select-window window-c t) ; buffer-c is made current
         (when (and (buffer-modified-p)
                    (y-or-n-p (format "'%s' was modified. Save before killing? " (buffer-name))))
-          (save-buffer))
+	  (with-file-modes #o700
+            (save-buffer)))
         (set-buffer-modified-p nil) ; Set buffer to not modified to not ask user
         (kill-buffer)
         (switch-to-buffer empty-buffer)))    ;; Kill file-a and file-b always. We want to explicitly set the current buffer


### PR DESCRIPTION
Prevents world-readable (Emacs default: #755) merge files for sensitive
config files (like /etc/shadow).

Without this commit:
```
-rw-r--r-- 1 juergen juergen     9 28. Okt 15:25  d19ca71d34.pacmerge
```

Using this commit:

```
-rw------- 1 juergen juergen     9 28. Okt 15:37  d19ca71d34.pacmerge
```