### PR TITLE
Add tramp support

### DIFF
--- a/pacfiles-buttons.el
+++ b/pacfiles-buttons.el
@@ -5,6 +5,8 @@
 ;;
 ;;; Code:
 
+(require 'tramp)
+
 (defgroup pacfiles-button-faces nil
   "Faces for the buttons used in pacfiles-mode."
   :group 'pacfiles)
@@ -77,9 +79,9 @@ FILE is removed."
                                                  (file-name-nondirectory base-file))
                               'action `(lambda (_)
                                          (ediff-merge-files
-					  (pacfiles--add-sudo-maybe ,update-file :read)
-					  (pacfiles--add-sudo-maybe ,base-file :read)
-					  nil
+                                          (pacfiles--add-sudo-maybe ,update-file :read)
+                                          (pacfiles--add-sudo-maybe ,base-file :read)
+                                          nil
                                           ;; location of the merged file-pair
                                           ,(cdr file-pair)))
                               'type 'pacfiles--button-generic)
@@ -126,8 +128,8 @@ FILE is removed."
                                                  (file-name-nondirectory file-update)
                                                  (file-name-nondirectory file-base))
                               'action `(lambda (_) (ediff-files
-						    (pacfiles--add-sudo-maybe ,file-update :read)
-						    (pacfiles--add-sudo-maybe ,file-base :read)))
+                                               (pacfiles--add-sudo-maybe ,file-update :read)
+                                               (pacfiles--add-sudo-maybe ,file-base :read)))
                               'type 'pacfiles--button-generic)
           (insert " "))
       ;; Replace the diff button with spaces

--- a/pacfiles-mode.el
+++ b/pacfiles-mode.el
@@ -86,7 +86,12 @@ Ignore IGNORE-AUTO but take into account NOCONFIRM."
       (run-hooks 'before-revert-hook)
       ;; The actual revert mechanism starts here
       (let ((inhibit-read-only t)
-            (files (split-string (shell-command-to-string pacfiles-updates-search-command) "\n" t))
+            (files (mapcar (lambda (file)
+			     (if (file-remote-p default-directory)
+				 (with-parsed-tramp-file-name default-directory nil
+				   (tramp-make-tramp-file-name method user domain host port file))
+			       file))
+			   (split-string (shell-command-to-string pacfiles-updates-search-command) "\n" t)))
             (merged-files (split-string (shell-command-to-string pacfiles--merge-search-command) "\n" t))
             (pacnew-alist (list))
             (pacsave-alist (list)))

--- a/pacfiles-mode.el
+++ b/pacfiles-mode.el
@@ -5,7 +5,7 @@
 ;; Author: Carlos G. Cordero <http://github/UndeadKernel>
 ;; Maintainer: Carlos G. Cordero <pacfiles@binarycharly.com>
 ;; Created: Oct 11, 2018
-;; Modified: Oct 14, 2018
+;; Modified: Apr 18, 2020
 ;; Version: 1.0
 ;; Keywords: files pacman arch pacnew pacsave update linux
 ;; URL: https://github.com/UndeadKernel/pacfiles-mode
@@ -38,7 +38,8 @@
 (defgroup pacfiles nil "Options that relate to ‘pacfiles-mode’."
   :group 'applications)
 
-(defvar pacfiles-updates-search-command "find /etc -name '*.pacnew' -o -name '*.pacsave' 2>/dev/null"
+(defvar pacfiles-updates-search-command
+  "find /etc -name '*.pacnew' -o -name '*.pacsave' 2>/dev/null"
   "Command to find .pacnew files.")
 
 (defvar pacfiles--merge-search-command
@@ -86,13 +87,12 @@ Ignore IGNORE-AUTO but take into account NOCONFIRM."
       (run-hooks 'before-revert-hook)
       ;; The actual revert mechanism starts here
       (let ((inhibit-read-only t)
-            (files (mapcar (lambda (file)
-			     (if (file-remote-p default-directory)
-				 (with-parsed-tramp-file-name default-directory nil
-				   (tramp-make-tramp-file-name method user domain host port file))
-			       file))
-			   (split-string (shell-command-to-string pacfiles-updates-search-command) "\n" t)))
-            (merged-files (split-string (shell-command-to-string pacfiles--merge-search-command) "\n" t))
+            (files (mapcar #'pacfiles--set-remote-path-maybe
+                           (split-string (shell-command-to-string
+                                          pacfiles-updates-search-command) "\n" t)))
+            (merged-files (mapcar #'pacfiles--set-remote-path-maybe
+                                  (split-string (shell-command-to-string
+                                                 pacfiles--merge-search-command) "\n" t)))
             (pacnew-alist (list))
             (pacsave-alist (list)))
         (delete-region (point-min) (point-max))
@@ -100,7 +100,9 @@ Ignore IGNORE-AUTO but take into account NOCONFIRM."
         ;; Split .pacnew and .pacsave files
         (dolist (file files)
           ;; Associate each FILE in FILES with a file to hold the merge
-          (let ((merge-file (pacfiles--calculate-merge-file file pacfiles-merge-file-tmp-location)))
+          (let ((merge-file
+                 (pacfiles--set-remote-path-maybe
+                  (pacfiles--calculate-merge-file file pacfiles-merge-file-tmp-location))))
             (cond
              ((string-match-p ".pacnew" file)
               (push (cons file merge-file) pacnew-alist))


### PR DESCRIPTION
Create corresponding tramp file names when `pacfiles' was started in a remote
default-directory.

Fixes #4
